### PR TITLE
Display command

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -12,20 +12,31 @@ void onConnected(MicroBitEvent)
 {
     uBit.display.print(IMAGE_HAPPY);
     connected = 1;
-
-    ManagedString eom("\n");
-    uart->eventOn(eom, ASYNC);
+    uart->eventOn(ManagedString("\n"), ASYNC);
 }
 
 void onUartEvent(MicroBitEvent)
 {
-    ManagedString msg = uart->readUntil(ManagedString(":"));
+    ManagedString msg = uart->readUntil(ManagedString(":"), ASYNC);
+    if (msg.length() == 0)
+    {
+        // Invalid command. Throw out rx buffer.
+        uart->readUntil(ManagedString("\n"));
+        return;
+    }
+
     if (msg == "disp")
     {
         msg = uart->readUntil(ManagedString("\n"));
         uBit.display.scroll(msg);
         uBit.display.print(IMAGE_HAPPY);
     }
+    else
+    {
+        // Unknown command. Throw out rx buffer.
+        uart->readUntil(ManagedString("\n"));
+    }
+    
 }
 
 void onDisconnected(MicroBitEvent)
@@ -83,7 +94,7 @@ int main()
 
     uBit.display.print("R");
     uBit.sleep(2000);
-    uBit.display.scroll(microbit_friendly_name());
+    uBit.display.scrollAsync(microbit_friendly_name());
     uBit.display.print("R");
 
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -1,65 +1,43 @@
-/*
-The MIT License (MIT)
-
-Copyright (c) 2016 British Broadcasting Corporation.
-This software is provided by Lancaster University by arrangement with the BBC.
-
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the "Software"),
-to deal in the Software without restriction, including without limitation
-the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-*/
-
-// Works with the Animal Vegetable Mineral guessing game in the Android 'micro:bit Blue' app which is obtainable from
-// https://play.google.com/store/apps/details?id=com.bluetooth.mwoolley.microbitbledemo
-
 #include "MicroBit.h"
 #include "MicroBitUARTService.h"
 
 MicroBit uBit;
 MicroBitUARTService *uart;
 
+const MicroBitImage IMAGE_HAPPY = MicroBitImage("0,0,0,0,0\n0,1,0,1,0\n0,0,0,0,0\n1,0,0,0,1\n0,1,1,1,0\n");  
+
 int connected = 0;
 
 void onConnected(MicroBitEvent)
 {
-
-    uBit.display.scroll("C");
-
+    uBit.display.print(IMAGE_HAPPY);
     connected = 1;
 
-    // mobile app will send ASCII strings terminated with the colon character
-    ManagedString eom(":");
+    ManagedString eom("\n");
+    uart->eventOn(eom, ASYNC);
+}
 
-    while(connected == 1) {
-        ManagedString msg = uart->readUntil(eom);
+void onUartEvent(MicroBitEvent)
+{
+    ManagedString msg = uart->readUntil(ManagedString(":"));
+    if (msg == "disp")
+    {
+        msg = uart->readUntil(ManagedString("\n"));
         uBit.display.scroll(msg);
+        uBit.display.print(IMAGE_HAPPY);
     }
-
 }
 
 void onDisconnected(MicroBitEvent)
 {
-    uBit.display.scroll("D");
+    uBit.display.print("R");
     connected = 0;
 }
 
 void onButtonA(MicroBitEvent)
 {
-    if (connected == 0) {
+    if (connected == 0)
+    {
         return;
     }
     uart->send(ManagedString("YES"));
@@ -68,7 +46,8 @@ void onButtonA(MicroBitEvent)
 
 void onButtonB(MicroBitEvent)
 {
-    if (connected == 0) {
+    if (connected == 0)
+    {
         return;
     }
     uart->send(ManagedString("NO"));
@@ -77,12 +56,14 @@ void onButtonB(MicroBitEvent)
 
 void onButtonAB(MicroBitEvent)
 {
-    if (connected == 0) {
+    if (connected == 0)
+    {
         return;
     }
     uart->send(ManagedString("GOT IT!!"));
     uBit.display.scroll("!");
 }
+
 
 int main()
 {
@@ -94,14 +75,17 @@ int main()
     uBit.messageBus.listen(MICROBIT_ID_BUTTON_A, MICROBIT_BUTTON_EVT_CLICK, onButtonA);
     uBit.messageBus.listen(MICROBIT_ID_BUTTON_B, MICROBIT_BUTTON_EVT_CLICK, onButtonB);
     uBit.messageBus.listen(MICROBIT_ID_BUTTON_AB, MICROBIT_BUTTON_EVT_CLICK, onButtonAB);
+    uBit.messageBus.listen(MICROBIT_ID_BLE_UART, MICROBIT_BLE_EVENT_SERVICE, onUartEvent);
 
     // Note GATT table size increased from default in MicroBitConfig.h
     // #define MICROBIT_SD_GATT_TABLE_SIZE             0x500
     uart = new MicroBitUARTService(*uBit.ble, 32, 32);
-    // uBit.display.scroll("ScrUART ready");
+
     uBit.display.print("R");
+    uBit.sleep(2000);
     uBit.display.scroll(microbit_friendly_name());
     uBit.display.print("R");
+
 
     // If main exits, there may still be other fibers running or registered event handlers etc.
     // Simply release this fiber, which will mean we enter the scheduler. Worse case, we then

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -15,6 +15,13 @@ void onConnected(MicroBitEvent)
     uart->eventOn(ManagedString("\n"), ASYNC);
 }
 
+void handleDisplay()
+{
+    ManagedString msg = uart->readUntil(ManagedString("\n"));
+    uBit.display.scrollAsync(msg);
+    uBit.display.print(IMAGE_HAPPY);
+}
+
 void onUartEvent(MicroBitEvent)
 {
     ManagedString msg = uart->readUntil(ManagedString(":"), ASYNC);
@@ -27,9 +34,7 @@ void onUartEvent(MicroBitEvent)
 
     if (msg == "disp")
     {
-        msg = uart->readUntil(ManagedString("\n"));
-        uBit.display.scrollAsync(msg);
-        uBit.display.print(IMAGE_HAPPY);
+        create_fiber(handleDisplay);
     }
     else
     {

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -28,7 +28,7 @@ void onUartEvent(MicroBitEvent)
     if (msg == "disp")
     {
         msg = uart->readUntil(ManagedString("\n"));
-        uBit.display.scroll(msg);
+        uBit.display.scrollAsync(msg);
         uBit.display.print(IMAGE_HAPPY);
     }
     else


### PR DESCRIPTION
Adds handling of the display command.

It can now display the message `Hello there!`, which is much more than the couple of characters the PXT version could display. It errors out if the string is much longer than that, though. I thought the limit could be the UART RX buffer size, but that didn't help. Is there a limit on the browser's TX buffer size?

