### PR TITLE
Add alternative Docker build option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:18.04
+
+RUN mkdir /app
+WORKDIR /app
+
+RUN apt update && apt install -y \
+    python-setuptools \
+    python-pip \
+    git \
+    cmake \
+    build-essential \
+    ninja-build \
+    python-dev \
+    libffi-dev \
+    libssl-dev \
+    srecord \
+    gcc-arm-none-eabi
+RUN pip install yotta
+
+ENTRYPOINT ["yt"]

--- a/README.md
+++ b/README.md
@@ -5,11 +5,24 @@ The Rovercode service for GiggleBot, written directly on the Lancaster C/C++ mBe
 
 * [Install yotta](https://lancaster-university.github.io/microbit-docs/offline-toolchains/#yotta)
 
+##### Alternative Docker image
+
+```
+sudo docker build . -t yt
+```
+
 ## Build
 
 ```
 yt clean
 yt build
+```
+
+##### Alternative Docker container
+
+```
+sudo docker run --rm -v ${PWD}:/app yt clean
+sudo docker run --rm -v ${PWD}:/app yt build
 ```
 
 ## Copy hex to the micro:bit


### PR DESCRIPTION
There are some issues with installing the toolchain on Ubuntu. The recommended path is to use the `gcc-arm-embedded` package from the `team-gcc-arm-embedded/ppa` PPA since the distribution `gcc-arm-none-eabi` package doesn't work. However, that PPA doesn't have packages for Ubuntu 20.04. Rather than make it complicated or do anything to potentially cause issues with the host OS, this provides a `Dockerfile` to build a Docker image that can run `yt` that will work on any Docker-supported system.